### PR TITLE
Add GitHub Actions workflow for automatic version bump

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,69 @@
+name: Auto Version Bump
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+      - dev
+
+jobs:
+  bump-version:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Read current version
+        id: current-version
+        run: |
+          VERSION=$(cat VERSION)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $VERSION"
+
+      - name: Bump version
+        id: new-version
+        run: |
+          CURRENT_VERSION="${{ steps.current-version.outputs.version }}"
+          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
+          
+          if [[ "${{ github.base_ref }}" == "main" ]]; then
+            # Merge to main: bump minor, reset patch
+            minor=$((minor + 1))
+            patch=0
+            echo "Bumping minor version (merge to main)"
+          elif [[ "${{ github.base_ref }}" == "dev" ]]; then
+            # Merge to dev: bump patch
+            patch=$((patch + 1))
+            echo "Bumping patch version (merge to dev)"
+          fi
+          
+          NEW_VERSION="$major.$minor.$patch"
+          echo "$NEW_VERSION" > VERSION
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Commit and push changes
+        run: |
+          git add VERSION
+          git commit -m "chore: bump version to ${{ steps.new-version.outputs.version }} [skip ci]"
+          git push origin ${{ github.base_ref }}
+
+      - name: Create git tag
+        if: github.base_ref == 'main'
+        run: |
+          git tag -a "v${{ steps.new-version.outputs.version }}" -m "Release v${{ steps.new-version.outputs.version }}"
+          git push origin "v${{ steps.new-version.outputs.version }}"


### PR DESCRIPTION
Add a GitHub Action workflow that update the patch number when a PR is merged in dev and the minor number when te PR is merge in main. 