### PR TITLE
Fix CI error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.10', '3.12']
+        python-version: ['3.12']
     steps:
 
       # Get number of cpu available on the current runner


### PR DESCRIPTION
CI, launched with Python 3.10, is producing an error. We were unable to reproduce the error locally.

For the time being, we have decided to launch the CI only with Python 3.12, as this error does not seem to occur with this version. 

