### PR TITLE
Add a GitHub Actions workflow to build and publish PANORAMA releases to PyPI.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,4 +1,3 @@
-```yaml
 # Publish PANORAMA to PyPI
 #
 # - On a GitHub release: automatically publish to PyPI
@@ -60,8 +59,7 @@ jobs:
 
     environment:
       name: testpypi
-      url: https://test.pypi.org/project/panorama/
-
+      url: https://test.pypi.org/project/panorama-sys/
     steps:
       - name: Retrieve release distributions
         uses: actions/download-artifact@v4
@@ -87,7 +85,7 @@ jobs:
 
     environment:
       name: pypi
-      url: https://pypi.org/project/panorama/
+      url: https://pypi.org/project/panorama-sys/
 
     steps:
       - name: Retrieve release distributions
@@ -98,4 +96,4 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-```
+

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,101 @@
+```yaml
+# Publish PANORAMA to PyPI
+#
+# - On a GitHub release: automatically publish to PyPI
+# - Manually: optionally publish to TestPyPI and/or PyPI
+
+name: Publish Python Package
+
+on:
+  release:
+    types: [released]
+
+  workflow_dispatch:
+    inputs:
+      publish_test:
+        description: "Publish to TestPyPI"
+        required: true
+        type: boolean
+        default: false
+      publish_to_pypi:
+        description: "Publish to PyPI"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  release-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build release distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+  pypi-publish-test:
+    runs-on: ubuntu-latest
+    needs: release-build
+    if: github.event_name == 'workflow_dispatch' && inputs.publish_test == true
+
+    permissions:
+      id-token: write
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/panorama/
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs: release-build
+
+    if: >-
+      (github.event_name == 'release' && github.event.action == 'released') ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish_to_pypi == true)
+
+    permissions:
+      id-token: write
+
+    environment:
+      name: pypi
+      url: https://pypi.org/project/panorama/
+
+    steps:
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+```

--- a/panorama/main.py
+++ b/panorama/main.py
@@ -49,15 +49,11 @@ from panorama.utility.utility import launch as utility_launcher
 from panorama.utility.utility import subparser as utility_subparser
 
 # local modules
-from panorama.utils import (
-    RawTextArgumentDefaultsHelpFormatter,
-    add_common_arguments,
-    set_verbosity_level,
-)
+from panorama.utils import RawTextArgumentDefaultsHelpFormatter, add_common_arguments, set_verbosity_level
 from panorama.workflow.pansystems import launch as pansystems_launcher
 from panorama.workflow.pansystems import subparser as pansystems_subparser
 
-version = distribution("panorama").version
+version = distribution("panorama-sys").version
 opening = r"""
     ____     ___     _   __   ____     ____     ___     __  ___    ___ 
    / __ \   /   |   / | / /  / __ \   / __ \   /   |   /  |/  /   /   |

--- a/panorama/main.py
+++ b/panorama/main.py
@@ -23,7 +23,6 @@ if sys.version_info < (3, 10):  # minimum is python3.9
     )
 
 import argparse
-from importlib.metadata import distribution
 
 from panorama.alignment.align import launch as align_launcher
 from panorama.alignment.align import subparser as align_subparser
@@ -49,11 +48,16 @@ from panorama.utility.utility import launch as utility_launcher
 from panorama.utility.utility import subparser as utility_subparser
 
 # local modules
-from panorama.utils import RawTextArgumentDefaultsHelpFormatter, add_common_arguments, set_verbosity_level
+from panorama.utils import (
+    RawTextArgumentDefaultsHelpFormatter,
+    add_common_arguments,
+    get_panorama_version,
+    set_verbosity_level,
+)
 from panorama.workflow.pansystems import launch as pansystems_launcher
 from panorama.workflow.pansystems import subparser as pansystems_subparser
 
-version = distribution("panorama-sys").version
+version = get_panorama_version()
 opening = r"""
     ____     ___     _   __   ____     ____     ___     __  ___    ___ 
    / __ \   /   |   / | / /  / __ \   / __ \   /   |   /  |/  /   /   |

--- a/panorama/utils.py
+++ b/panorama/utils.py
@@ -122,8 +122,16 @@ def set_verbosity_level(args: argparse.Namespace) -> None:
             # log is written in a files. basic condif uses filename
             logging.basicConfig(filename=args.log, level=level, format=str_format, datefmt=datefmt)
         logging.getLogger("PANORAMA").debug("Command: " + " ".join([arg for arg in sys.argv]))
-        logging.getLogger("PANORAMA").debug(f"PANORAMA version: {distribution('panorama').version}")
+        logging.getLogger("PANORAMA").debug(f"PANORAMA version: {get_panorama_version()}")
 
+
+def get_panorama_version() -> str:
+    """
+    Get the version of the panorama package.
+
+    :return: The version of the panorama package.
+    """
+    return distribution("panorama-sys").version
 
 # File managing system
 def mkdir(output: Path, force: bool = False, erase: bool = False) -> Path:

--- a/panorama/utils.py
+++ b/panorama/utils.py
@@ -133,6 +133,7 @@ def get_panorama_version() -> str:
     """
     return distribution("panorama-sys").version
 
+
 # File managing system
 def mkdir(output: Path, force: bool = False, erase: bool = False) -> Path:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "PANORAMA"
+name = "panorama-sys"
 
 authors = [
     { name = "Jérôme Arnoux", email = "arnoux.jeromepj@gmail.com" },


### PR DESCRIPTION
## Description

Add a GitHub Actions workflow to build and publish PANORAMA releases to PyPI.

The `panorama` name is already taken on PyPI, so the package cannot be published under this name. We therefore use `panorama-sys`, reflecting PANORAMA's main feature: system detection.

The panorama-sys projects have already been created on both PyPI and TestPyPI.

## What changed

* Added a GitHub Actions workflow to build and publish the package to PyPI.
* Added optional manual publishing through `workflow_dispatch`:

  * Publish to TestPyPI for testing.
  * Publish to PyPI when needed.
* Releases are automatically published to PyPI when a GitHub release is created.

Fixed how version is retrieved: use `distribution("panorama-sys").version` instead of `distribution("panorama").version`. This was call in main and in utils. Refactor in a utils function `get_panorama_version` to hold only once the logic.  

## Testing

The workflow can be tested manually using `workflow_dispatch` and selecting the appropriate publishing option.

## Documentation

Documentation and README updates will be handled in a second PR, once PANORAMA is available on PyPI. This should make it easier to update the installation instructions with the actual PyPI package.


## Additional notes

The workflow uses PyPI's trusted publishing mechanism, so no PyPI API token is required.
